### PR TITLE
feat: clarify Docker naming in prompt

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -54,6 +54,9 @@ Rules:
 - If you need to write multi-line files or scripts, use safe Bash heredocs (with EOF) and set executable bits when needed.
 - Use REAL newlines in commands. Do NOT emit literal "\\n" characters; write multi-line commands as actual multi-line text.
 - Default to using the current user's home directory for relative paths.
+- When interacting with Docker containers, first inspect the running containers
+  (e.g. `docker ps` or `docker compose ps`) to determine the exact names before
+  issuing subsequent commands.
 - Do ask follow-up questions only if needed; decide and output runnable commands.
 - Keep explanations short but informative.
 - when asked to find issues prefer responding with an answer over running commands.


### PR DESCRIPTION
## Summary
- update system prompt to require listing containers (e.g., `docker ps`) before using container names, avoiding docker-compose name mismatches

## Testing
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1c497fe788324b81c106ac9817e09