### PR TITLE
Add completion check before agent exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ troubleshooting networked applications such as Docker containers, verify the
 expected port mapping and test connectivity from both the host and any peer
 containers.
 
+After running its planned commands, the agent now double‑checks whether the
+task is complete. When it believes the job is finished, it prints a concise
+summary of what was accomplished and then exits.
+
 ## Scenario Library
 
 See [SCENARIOS.md](SCENARIOS.md) for fifty example Linux issues ranging from


### PR DESCRIPTION
## Summary
- add `assess_completion` helper to ask the model if the task is finished and to summarize the result
- main loop now prints the summary and exits when the model reports completion
- document the new behavior in the README

## Testing
- `python -m py_compile agent.py run_scenarios.py`
- `python run_scenarios.py 1`


------
https://chatgpt.com/codex/tasks/task_e_68c24ef5d8bc8324869f7883038a7bce