### PR TITLE
Add Docker network scenario runner and improve network guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ summary of what was accomplished and then exits.
 See [SCENARIOS.md](SCENARIOS.md) for fifty example Linux issues ranging from
 package manager failures to Docker misconfigurations. They can be used to test
 and harden the agent against a wide variety of real‑world situations.
+
+## Network Scenario Testing
+
+Run `./run_docker_network_scenarios.py` to evaluate the agent against five
+common Docker network failure scenarios.

--- a/SCENARIOS.md
+++ b/SCENARIOS.md
@@ -53,3 +53,6 @@ A reference list of diverse issues the agent should be prepared to handle.
 49. Initramfs missing modules causing boot failure
 50. Log rotation fails, causing large log files
 
+51. Docker container cannot reach external network due to missing default route
+52. Docker container port published but host firewall blocks access
+

--- a/agent.py
+++ b/agent.py
@@ -64,6 +64,9 @@ Rules:
 - When diagnosing network services, confirm you are probing the correct
   service and port. Verify port mappings and test from both the host and any
   relevant containers instead of trusting responses from unrelated ports.
+- For Docker networking issues, inspect container networks (`docker network ls`,
+  `docker network inspect`) and test connectivity from within containers using
+  `docker exec <container> ping -c1 <host>`.
 - Expect a wide range of Linux troubleshooting scenarios (e.g. package
   management failures, Docker daemon issues, service misconfigurations,
   permission problems) and craft commands accordingly.

--- a/run_docker_network_scenarios.py
+++ b/run_docker_network_scenarios.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Run the agent against Docker network-related scenarios."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import agent
+
+SCENARIOS_FILE = Path(__file__).with_name("SCENARIOS.md")
+SCENARIO_NUMBERS = [28, 29, 33, 51, 52]
+
+
+def load_selected_scenarios(path: Path, numbers: list[int]) -> list[str]:
+    """Load scenarios by their list numbers."""
+    mapping: dict[int, str] = {}
+    for line in path.read_text().splitlines():
+        match = re.match(r"(\d+)\.\s+(.*)", line)
+        if match:
+            mapping[int(match.group(1))] = match.group(2).strip()
+    return [mapping[n] for n in numbers if n in mapping]
+
+
+def run() -> None:
+    scenarios = load_selected_scenarios(SCENARIOS_FILE, SCENARIO_NUMBERS)
+    for idx, desc in enumerate(scenarios, 1):
+        print(f"\n=== Scenario {idx}: {desc} ===")
+        messages = [{"role": "system", "content": agent.SYSTEM_PROMPT}]
+        task = f"Investigate and resolve: {desc}"
+        messages.append({"role": "user", "content": task})
+        try:
+            plan = agent.plan_commands(messages)
+            print("[AI]", plan.get("explanation", ""))
+            output = agent.run_commands(plan["commands"])
+            if output.strip():
+                print(output)
+        except Exception as exc:
+            print(f"[Agent error] {exc}")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- clarify network troubleshooting instructions for Docker in the agent prompt
- add Docker network-specific scenarios to SCENARIOS.md
- provide script to run the agent against five Docker network scenarios
- document new script in README

## Testing
- `./run_docker_network_scenarios.py` *(fails: OpenAI API call hangs without key)*
- `python run_scenarios.py` *(fails: OpenAI API call hangs without key)*

------
https://chatgpt.com/codex/tasks/task_e_68c488e317ac832492b556140121af1a