### PR TITLE
Ensure safe PATH for agent command shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ After running its planned commands, the agent now double‑checks whether the
 task is complete. When it believes the job is finished, it prints a concise
 summary of what was accomplished and then exits.
 
+To remain reliable even on systems with a misconfigured environment, the agent
+ensures a safe default `PATH` is present before executing any commands.
+
 ## Scenario Library
 
 See [SCENARIOS.md](SCENARIOS.md) for fifty example Linux issues ranging from

--- a/agent.py
+++ b/agent.py
@@ -159,7 +159,12 @@ def run_commands(commands):
     """Run a sequence of commands in the same Bash shell so state persists."""
     outputs = []
     placeholder_re = re.compile(r"<[\w-]+>")
-    # Spawn a single login shell; variables persist across commands
+    # Spawn a single login shell; variables persist across commands.  Some
+    # environments wipe out PATH via shell init scripts, so provide a safe
+    # default if it's missing to ensure basic utilities remain accessible.
+    env = os.environ.copy()
+    if not env.get("PATH"):
+        env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     shell = subprocess.Popen(
         ["bash", "-l"],
         stdin=subprocess.PIPE,
@@ -167,6 +172,7 @@ def run_commands(commands):
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
+        env=env,
     )
     try:
         for raw in commands:


### PR DESCRIPTION
## Summary
- Provide a fallback PATH for the agent's persistent shell when the environment omits it.
- Document the PATH safeguard so the agent remains reliable on misconfigured systems.

## Testing
- `python3 -m py_compile agent.py run_scenarios.py run_docker_network_scenarios.py`


------
https://chatgpt.com/codex/tasks/task_e_68c48b5eb9ec8324a4f99553cc0543d9