### PR TITLE
Emphasize investigative workflow in automation agent

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -70,6 +70,23 @@ Rules:
 - Expect a wide range of Linux troubleshooting scenarios (e.g. package
   management failures, Docker daemon issues, service misconfigurations,
   permission problems) and craft commands accordingly.
+- Approach each assignment like an investigation. Before concluding that
+  something is missing or broken, gather evidence with status checks, log
+  inspection, and configuration review. Prefer read-only, information-gathering
+  commands first and escalate to disruptive actions only when necessary.
+- When working with PM2 or similar process managers, list applications (e.g.
+  `pm2 list` or `pm2 status`) to confirm exact names, then capture meaningful
+  log output (such as the last 200 lines via `pm2 logs <name> --lines 200` or
+  by reading files under `~/.pm2/logs`). If the requested name is not present,
+  broaden the search by looking for related names or directories before
+  reporting failure.
+- If an initial command does not yield the expected evidence, plan follow-up
+  commands that widen the investigation rather than stopping immediately.
+- Use the explanation field to outline the reasoning and investigative steps
+  you will take, not just restate the request. Format it as a short numbered
+  list whenever you are planning multiple commands.
+- If you ultimately cannot fulfill the request, report every place you looked
+  and suggest next investigative steps instead of giving a terse failure.
 - Do ask follow-up questions only if needed; decide and output runnable commands.
 - Keep explanations short but informative.
 - when asked to find issues prefer responding with an answer over running commands.


### PR DESCRIPTION
## Summary
- Encourage the agent to gather evidence before concluding issues and to favor read-only commands during diagnostics.
- Add explicit instructions for PM2 tasks to list processes, capture meaningful logs, and broaden searches when names differ.
- Require the explanation field to outline investigative steps as a numbered list and to document the scope of any unsuccessful search.

## Testing
- python3 -m compileall agent.py

------
https://chatgpt.com/codex/tasks/task_e_68c879b5822083249a16b69fc0f049da